### PR TITLE
Update HTML doc generation settings

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -1,6 +1,8 @@
 defmodule TimeQueue.MixProject do
   use Mix.Project
 
+  @source_url "https://github.com/lud/time_queue"
+
   def project do
     [
       app: :time_queue,
@@ -23,12 +25,13 @@ defmodule TimeQueue.MixProject do
   defp package() do
     [
       description: """
-      TimeQueue is a simple functional timer queue (no processes, no messaging, no erlang timers) based on gb_trees.
+      TimeQueue is a simple functional timer queue (no processes, no messaging,
+      no erlang timers) based on gb_trees.
       """,
       licenses: ["MIT"],
       links: %{
-        "Github" => "https://github.com/lud/time_queue",
-        "CHANGELOG" => "https://github.com/lud/time_queue/blob/master/CHANGELOG.md"
+        "Github" => @source_url,
+        "CHANGELOG" => "#{@source_url}/blob/master/CHANGELOG.md"
       }
     ]
   end
@@ -45,7 +48,11 @@ defmodule TimeQueue.MixProject do
 
   defp docs do
     [
-      main: "TimeQueue"
+      main: "TimeQueue",
+      source_url: @source_url,
+      extras: [
+        "README.md"
+      ]
     ]
   end
 


### PR DESCRIPTION
This PR updates the HTML doc generation by:

1. Enabling links to from doc to source code in Github for easy code reference and reading. See screenshot.
2. Adding README as part of the HTML doc so we can read everything in one place.

![image](https://user-images.githubusercontent.com/134518/94985759-cc3bdb80-058b-11eb-9d65-ec03eacdbf37.png)
